### PR TITLE
Remove the class property of the action bar

### DIFF
--- a/getting-started-vue/03.md
+++ b/getting-started-vue/03.md
@@ -18,7 +18,7 @@ Your task in this step is to use the `flat` property to remove the translucency 
 
 #### Action
 
-* **a.** Change the title of the `<ActionBar>` and set the `flat` property to `true`.
+* **a.** Change the title of the `<ActionBar>` and set the `flat` property to `true`. Remove the class property.
 
 ```HTML
 <ActionBar title=" " flat="true" />


### PR DESCRIPTION
By default, the class property is added. This is not needed in this tutorial