### PR TITLE
Add a note about dark mode

### DIFF
--- a/groceries-js/2.md
+++ b/groceries-js/2.md
@@ -157,6 +157,8 @@ StackLayout {
 ![](images/ios-6.png)
 ![](images/android-6.png)
 
+> **NOTE**: If your iOS device in is "dark mode" then you may not be able to see the "Email Address" and "Password" text inside the TextField elements until the next stop in this tutorial, covering the NativeScript Core theme. Until then you may want to disable "dark mode" on your device.
+
 <hr data-action="end" />
 
 If you've done any web development before, the syntax should feel familiar here. You select two UI components by their tag names (`FlexboxLayout` and `StackLayout`), and then apply a handful of CSS rules as name/value pairs.


### PR DESCRIPTION
After the first CSS step, iOS devices in "dark mode" may not be able to see the "Email Address" and "Password" field hints until the next step when the core theme is applied. I am unsure whether this is an issue in NativeScript that needs fixing or not, but for now, I would like to add this note to the tutorial to help other potentially confused learners.