### PR TITLE
Correct deprecated use of frameModule.topmost()

### DIFF
--- a/groceries-js/4.md
+++ b/groceries-js/4.md
@@ -110,7 +110,7 @@ function login() {
             return Promise.reject();
         })
         .then(function() {
-            frameModule.topmost().navigate("views/list/list-page");
+            frameModule.Frame.topmost().navigate("views/list/list-page");
         });
 };
 


### PR DESCRIPTION
In the previous step(s) this was already corrected, but this step introduces a deprecated call "frameModule.topmost()" which will result in a deprecation warning being output to the playground console. Instead, use "frameModule.Frame.topmost()" (as in prior steps) which will avoid generating this warning. (Unless you want to add this as an "extra credit" style fix for playground learners...)