### PR TITLE
Fix link to nonexistent page

### DIFF
--- a/groceries-js/2.md
+++ b/groceries-js/2.md
@@ -66,7 +66,7 @@ The code above adds two new NativeScript UI components: a [text field](https://d
 - `<Button>`
     - `text`: Controls the text displayed within the button.
 
-There are [many UI components](https://docs.nativescript.org/angular/ui/components) you can use to build NativeScript apps, and you might want to take some time to explore all that’s out there.
+There are [many UI components](http://docs.nativescript.org/ui/ui-views) you can use to build NativeScript apps, and you might want to take some time to explore all that’s out there.
 
 Next, let’s focus on the other new UI component in the above example—`<StackLayout>`—and discuss how to organize your UI components in NativeScript apps.
 


### PR DESCRIPTION
The link to "many UI components" in the tutorial Lesson 2 is pointing to a nonexistent page so it 404s.