### PR TITLE
Update 08.md

### DIFF
--- a/getting-started-vue/08.md
+++ b/getting-started-vue/08.md
@@ -2,7 +2,7 @@
 
 ### Step 19. Styling the currently selected tab title
 
-`<BottomNavigation>` supports the CSS `:active` pseudo selecvtor to change the selected/deselected state of `TabStripItem` or `TabStripContent`.
+`<BottomNavigation>` supports the CSS `:active` pseudo selector to change the selected/deselected state of `TabStripItem` or `TabStripContent`.
 
 Use inline NativeScript-specific CSS to change the color and font size of the tab titles.
 
@@ -10,15 +10,15 @@ Use inline NativeScript-specific CSS to change the color and font size of the ta
 
 #### Action
 
-* **a.** In `HelloWorld.vue`, add the `tabstripitem` CSS class to the `style` section. 
+* **a.** In `HelloWorld.vue`, add the `<TabStripItem>` styles to the `style` section. 
 
 ```CSS
 <style scoped>
-    TabStripItem.tabstripitem {
+    TabStripItem {
         background-color: teal;
     }
 
-    TabStripItem.tabstripitem:active {
+    TabStripItem:active {
         background-color: yellowgreen;
     }
 </style>


### PR DESCRIPTION
`tabstripitem` classes were not added to the `<TabStripItem>` component so there's no point using those classes for styling.